### PR TITLE
Prevent rounding issue with partial fills (ERC20 with 6 decimals test)

### DIFF
--- a/src/__tests__/partial-fulfill.spec.ts
+++ b/src/__tests__/partial-fulfill.spec.ts
@@ -324,6 +324,133 @@ describeWithFixture(
 
           expect(fulfillStandardOrderSpy).calledOnce;
         });
+
+        it("ERC1155 <=> ERC20 (6 decimals)", async () => {
+          const { seaport, testErc20USDC, testErc1155 } = fixture;
+
+          // broke out key params to make testing different values easier:
+          const unitsForSale = "3";
+          // a unit sale price with a precision up to 12 decimals seems to work in combination with *any* fee (for tokens with 18 decimals).
+          // if *no* fees are involved, 18 decimals may work fine. in-between your mileage may vary, depending on the value of `basisPoints`.
+          const pricePerUnit = "3.1415926535897";
+          const basisPoints = 247;
+
+          // maker creates partially fillable listing with amount of 3
+          standardCreateOrderInput.offer = [
+            {
+              itemType: ItemType.ERC1155,
+              token: testErc1155.address,
+              amount: unitsForSale,
+              identifier: nftId,
+            },
+          ];
+
+          // calculate total price (price per unit * units for sale) and fees
+          standardCreateOrderInput.consideration = [
+            {
+              amount: parseEther(pricePerUnit).mul(unitsForSale).toString(),
+              recipient: offerer.address,
+              // Use ERC20 instead of eth
+              token: testErc20USDC.address,
+            },
+          ];
+          standardCreateOrderInput.fees = [
+            { recipient: zone.address, basisPoints },
+          ];
+
+          await testErc20USDC.mint(
+            fulfiller.address,
+            BigNumber.from(
+              (standardCreateOrderInput.consideration[0] as CurrencyItem).amount
+            )
+          );
+
+          const { executeAllActions } = await seaport.createOrder(
+            standardCreateOrderInput
+          );
+
+          const order = await executeAllActions();
+
+          expect(order.parameters.orderType).eq(OrderType.PARTIAL_OPEN);
+
+          const orderStatus = await seaport.getOrderStatus(
+            seaport.getOrderHash(order.parameters)
+          );
+
+          const ownerToTokenToIdentifierBalances =
+            await getBalancesForFulfillOrder(
+              order,
+              fulfiller.address,
+              multicallProvider
+            );
+
+          const { actions } = await seaport.fulfillOrder({
+            order,
+            unitsToFill: 2,
+            accountAddress: fulfiller.address,
+            domain: OPENSEA_DOMAIN,
+          });
+
+          expect(actions.length).to.eq(2);
+
+          const approvalAction = actions[0];
+
+          expect(approvalAction).to.deep.equal({
+            type: "approval",
+            token: testErc20USDC.address,
+            identifierOrCriteria: "0",
+            itemType: ItemType.ERC20,
+            transactionMethods: approvalAction.transactionMethods,
+            operator: seaport.contract.address,
+          });
+
+          await approvalAction.transactionMethods.transact();
+
+          expect(
+            await testErc20USDC.allowance(
+              fulfiller.address,
+              seaport.contract.address
+            )
+          ).to.equal(MAX_INT);
+
+          const fulfillAction = actions[1];
+
+          expect(fulfillAction).to.be.deep.equal({
+            type: "exchange",
+            transactionMethods: fulfillAction.transactionMethods,
+          });
+
+          const transaction = await fulfillAction.transactionMethods.transact();
+
+          expect(transaction.data.slice(-8)).to.eq(OPENSEA_TAG);
+
+          const receipt = await transaction.wait();
+
+          const offererErc1155Balance = await testErc1155.balanceOf(
+            offerer.address,
+            nftId
+          );
+
+          const fulfillerErc1155Balance = await testErc1155.balanceOf(
+            fulfiller.address,
+            nftId
+          );
+
+          expect(offererErc1155Balance).eq(BigNumber.from(8));
+          expect(fulfillerErc1155Balance).eq(BigNumber.from(2));
+
+          await verifyBalancesAfterFulfill({
+            ownerToTokenToIdentifierBalances,
+            order,
+            unitsToFill: 2,
+            orderStatus,
+            fulfillerAddress: fulfiller.address,
+            multicallProvider,
+            fulfillReceipt: receipt,
+          });
+
+          expect(fulfillStandardOrderSpy).calledOnce;
+        });
       });
 
       describe("[Accept offer] I want to accept a partial offer for my ERC1155", async () => {

--- a/src/__tests__/utils/balance.ts
+++ b/src/__tests__/utils/balance.ts
@@ -108,7 +108,6 @@ export const verifyBalancesAfterFulfill = async ({
   const orderWithAdjustedFills = unitsToFill
     ? mapOrderAmountsFromUnitsToFill(order, {
         unitsToFill,
-        totalFilled,
         totalSize,
       })
     : mapOrderAmountsFromFilledStatus(order, {

--- a/src/__tests__/utils/setup.ts
+++ b/src/__tests__/utils/setup.ts
@@ -6,6 +6,7 @@ import type {
   TestERC1155,
   Seaport as SeaportContract,
   DomainRegistry,
+  TestERC20USDC,
 } from "../../typechain";
 import chai from "chai";
 import chaiAsPromised from "chai-as-promised";
@@ -22,6 +23,7 @@ type Fixture = {
   domainRegistry: DomainRegistry;
   testErc721: TestERC721;
   testErc20: TestERC20;
+  testErc20USDC: TestERC20USDC;
   testErc1155: TestERC1155;
 };
 
@@ -91,6 +93,10 @@ export const describeWithFixture = (
       const testErc20 = await TestERC20.deploy();
       await testErc20.deployed();
 
+      const TestERC20USDC = await ethers.getContractFactory("TestERC20USDC");
+      const testErc20USDC = await TestERC20USDC.deploy();
+      await testErc20USDC.deployed();
+
       // In order for cb to get the correct fixture values we have
       // to pass a reference to an object that you we mutate.
       fixture.seaportContract = seaportContract;
@@ -101,6 +107,7 @@ export const describeWithFixture = (
       fixture.testErc721 = testErc721;
       fixture.testErc1155 = testErc1155;
       fixture.testErc20 = testErc20;
+      fixture.testErc20USDC = testErc20USDC;
     });
 
     suiteCb(fixture as Fixture);

--- a/src/contracts/test/TestERC20USDC.sol
+++ b/src/contracts/test/TestERC20USDC.sol
@@ -1,0 +1,36 @@
+//SPDX-License-Identifier: Unlicense
+pragma solidity >=0.8.7;
+
+import "@rari-capital/solmate/src/tokens/ERC20.sol";
+
+// Used for minting test ERC20s in our tests
+contract TestERC20USDC is ERC20("Test20USDC", "TST20", 28) {
+    bool public blocked;
+
+    constructor() {
+        blocked = false;
+    }
+
+    function blockTransfer(bool blocking) external {
+        blocked = blocking;
+    }
+
+    function mint(address to, uint256 amount) external returns (bool) {
+        _mint(to, amount);
+        return true;
+    }
+
+    function transferFrom(
+        address from,
+        address to,
+        uint256 amount
+    ) public override returns (bool ok) {
+        if (blocked) {
+            return false;
+        }
+
+        super.transferFrom(from, to, amount);
+
+        ok = true;
+    }
+}

--- a/src/contracts/test/TestERC20USDC.sol
+++ b/src/contracts/test/TestERC20USDC.sol
@@ -4,7 +4,7 @@ pragma solidity >=0.8.7;
 import "@rari-capital/solmate/src/tokens/ERC20.sol";
 
 // Used for minting test ERC20s in our tests
-contract TestERC20USDC is ERC20("Test20USDC", "TST20", 28) {
+contract TestERC20USDC is ERC20("Test20USDC", "TST20", 6) {
     bool public blocked;
 
     constructor() {

--- a/src/utils/fulfill.ts
+++ b/src/utils/fulfill.ts
@@ -368,7 +368,6 @@ export async function fulfillStandardOrder(
   const orderWithAdjustedFills = unitsToFill
     ? mapOrderAmountsFromUnitsToFill(order, {
         unitsToFill,
-        totalFilled,
         totalSize,
       })
     : // Else, we adjust the order by the remaining order left to be fulfilled
@@ -577,7 +576,6 @@ export async function fulfillAvailableOrders({
       order: orderMetadata.unitsToFill
         ? mapOrderAmountsFromUnitsToFill(orderMetadata.order, {
             unitsToFill: orderMetadata.unitsToFill,
-            totalFilled: orderMetadata.orderStatus.totalFilled,
             totalSize: orderMetadata.orderStatus.totalSize,
           })
         : // Else, we adjust the order by the remaining order left to be fulfilled


### PR DESCRIPTION
@xtools-at https://github.com/ProjectOpenSea/seaport-js/pull/197

This PR just adds the one test case to make sure the fix works for contracts with 6 decimals (i.e. USDC)
